### PR TITLE
rp1 bugfix

### DIFF
--- a/gg_rescale.py
+++ b/gg_rescale.py
@@ -58,9 +58,10 @@ def gg_rescale(model_dir, model_file, radius_star, radius_planet, gravity_planet
 
 	# Calculate the transmission spectrum based on the file parameters
 	#	 to get the baseline radius
-	h1 = (kb * temperature_model) / (mu_model * gravity_model) # Calculate the scale height of the model atmosphere
-	rp1 = np.sqrt(model_rp) * rsun #cm
-	z1 = rp1 - (np.sqrt(model_rp[2000])*rsun) #cm
+	h1  = (kb * temperature_model) / (mu_model * gravity_model) # Calculate the scale height of the model atmosphere
+	r1  = np.sqrt(model_rp) * rsun #cm - observed radius
+	rp1 = rjup #cm - models use Rp = Rjup for bulk radius
+	z1  = r1 - rp1 #cm
 	epsig1 = tau * np.sqrt((kb * temperature_model * mu_model * gravity_model) / (2. * np.pi * rp1)) * np.exp(z1 / h1)
 
 	# Rescale the model atmosphere based on the input parameters


### PR DESCRIPTION
I was using the code to scale the grid, and I noticed that there was a bug.  When scaling a model to the same input parameters, it would give back a different spectrum.  But, this scenario should be returning the same exact spectrum as the input model file.

Looking in the code, this was due to some bugs where 
- `rp1` was being set to the observed radius Rp_obs, instead of the bulk radius Rp_bulk, and 
- the bulk radius was being selected from a specific index out of the observed radius, instead of the known radius of 1 Rjup.
This led to an erroneous `epsig1` calculation: the code uses Rp_obs, but Eq. 2 in the paper uses Rp_bulk.  Additionally, `z1` is slightly off since Rp_bulk was being selected from some index in the model spectrum instead of the known Rp_bulk of 1 Rjup.

The code modifications here correct both of these errors.  Now, when scaling a model to the same input parameters, it returns the same spectrum as the input model file.